### PR TITLE
readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ Public methods are also available to make operations on the tree, e.g. a Tree ob
     # Remove a node and free the memory along with its successors.
     t.remove_node(nid)
 
-    # Remove a node link its children to its parent (root is not allowd)
-    r.link_past_node(nid)
+    # Remove a node link its children to its parent (root is not allowed)
+    t.link_past_node(nid)
  
     # Search the tree from `nid` to the root along links reversedly
     # Note: `filter` refers to the function of one varible to act on the **node object**.


### PR DESCRIPTION
Thanks for merging in those things. Will try to think up a better way of giving leaves (it worked for what i needed at the time :) )

Two minor typo's in the readme. It should be:

# Remove a node link its children to its parent (root is not allowed)
t.link_past_node(nid)

instead of:

# Remove a node link its children to its parent (root is not allowd)
r.link_past_node(nid)
