### PR TITLE
Fix #32: subtree() cannot cooperate with rsearch()

### DIFF
--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -206,6 +206,9 @@ class TreeCase(unittest.TestCase):
         self.assertEqual(subtree_copy.parent("jane") is None, True)
         subtree_copy["jane"].tag = "Sweeti"
         self.assertEqual(self.tree["jane"].tag == "Jane", True)
+        self.assertEqual(subtree_copy.level("diane"), 1)
+        self.assertEqual(subtree_copy.level("jane"), 0)
+        self.assertEqual(self.tree.level("jane"), 1)
 
     def test_remove_subtree(self):
         subtree_shallow = self.tree.remove_subtree("jane")

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -478,7 +478,8 @@ class Tree(object):
         while current is not None:
             if filter(self[current]):
                 yield current
-            current = self[current].bpointer
+            # subtree() hasn't update the bpointer
+            current = self[current].bpointer if self.root != current else None
 
     def save2file(self, filename, nid=None, level=ROOT, idhidden=True,
                   filter=None, key=None, reverse=False, line_type='ascii-ex'):


### PR DESCRIPTION
1. subtree() hasn't taken care the original bpointer of it's root node
   which broke rsearch().
2. Add a if-condition on rsearch() to make sure it will break if
   tree.root (string) equals current (string)

Note: There are 2 solutions I can come up with which are modifying codes in subtree() or rsearch(), this one is modifying rsearch()
