### PR TITLE
Tree.__str__()

### DIFF
--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -253,20 +253,13 @@ class TreeCase(unittest.TestCase):
                          depth-1)
 
     def test_print_backend(self):
-        reader = BytesIO()
-
-        def write(line):
-            reader.write(line + b'\n')
-
-        self.tree._print_backend(func=write)
-
-        assert reader.getvalue() == """\
+        assert str(self.tree) == """\
 Hárry
 ├── Bill
 │   └── George
 └── Jane
     └── Diane
-""".encode('utf8')
+"""
 
     def tearDown(self):
         self.tree = None

--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+import sys
 try:
     from StringIO import StringIO as BytesIO
 except ImportError:
@@ -253,13 +254,20 @@ class TreeCase(unittest.TestCase):
                          depth-1)
 
     def test_print_backend(self):
-        assert str(self.tree) == """\
+        expected_result = u"""\
 Hárry
 ├── Bill
 │   └── George
 └── Jane
     └── Diane
 """
+
+        if sys.version_info[0] == 2:
+            # Python2.x :
+            assert str(self.tree) == expected_result.encode('utf-8')
+        else:
+            # Python3.x :
+            assert str(self.tree) == expected_result
 
     def tearDown(self):
         self.tree = None

--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -254,7 +254,7 @@ class TreeCase(unittest.TestCase):
                          depth-1)
 
     def test_print_backend(self):
-        expected_result = u"""\
+        expected_result = """\
 Hárry
 ├── Bill
 │   └── George


### PR DESCRIPTION
Since I think it's convenient that every Python object may be introspected with its __str__()  method, I suggest adding such a method to the Tree class. The suggested Tree.__str__() method simply returns what is "drawn" by Tree._print_backend().
The code seems ok with Python2/3; the tests are ok with Python3.

o added Tree.__str__() method, by simply returning the value returned by
  Tree._print_backend().
o since __str__() in Python2 doesn't have to return non-unicode characters,
  I used a trick found in Django's code, a decorator above the Tree class.
  (see http://django.readthedocs.org/en/latest/_modules/django/utils/encoding.html)
o modified TestCase.test_print_backend() by using the __str__() method.
