### PR TITLE
Export tree to the dot format

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -3,11 +3,11 @@
 from __future__ import unicode_literals
 from treelib import Tree
 from treelib.plugins import *
-import codecs
 import os
 import unittest
 
-class PluginCase(unittest.TestCase):
+class DotExportCase(unittest.TestCase):
+    """Test class for the export to dot format function"""
 
     def setUp(self):
         tree = Tree()
@@ -25,7 +25,7 @@ class PluginCase(unittest.TestCase):
         
         return generated
     
-    def test_to_dot(self):
+    def test_export_to_dot(self):
         export_to_dot(self.tree, 'tree.dot')
         expected = """\
 digraph tree {
@@ -47,7 +47,7 @@ digraph tree {
         self.assertEqual(generated, expected, "Generated dot tree is not the expected one")  
         os.remove('tree.dot')
         
-    def test_to_dot_empty_tree(self):
+    def test_export_to_dot_empty_tree(self):
         empty_tree = Tree()
         export_to_dot(empty_tree, 'tree.dot')
         

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from treelib import Tree
+from treelib.plugins import *
+import codecs
+import os
+import unittest
+
+class PluginCase(unittest.TestCase):
+
+    def setUp(self):
+        tree = Tree()
+        tree.create_node("Hárry", "hárry")
+        tree.create_node("Jane", "jane", parent="hárry")
+        tree.create_node("Bill", "bill", parent="hárry")
+        tree.create_node("Diane", "diane", parent="jane")
+        tree.create_node("George", "george", parent="bill")
+        self.tree = tree
+    
+    def read_generated_output(self, filename):
+        output = codecs.open(filename, 'r', 'utf-8')
+        generated = output.read()
+        output.close()
+        
+        return generated
+    
+    def test_to_dot(self):
+        export_to_dot(self.tree, 'tree.dot')
+        expected = """\
+digraph tree {
+\thárry [label="Hárry", shape=circle]
+\tbill [label="Bill", shape=circle]
+\tjane [label="Jane", shape=circle]
+\tgeorge [label="George", shape=circle]
+\tdiane [label="Diane", shape=circle]
+
+\thárry -> jane
+\thárry -> bill
+\tbill -> george
+\tjane -> diane
+}"""
+        
+        self.assertTrue(os.path.isfile('tree.dot'), "The file tree.dot could not be found.")
+        generated = self.read_generated_output('tree.dot')
+        
+        self.assertEqual(generated, expected, "Generated dot tree is not the expected one")  
+        os.remove('tree.dot')
+        
+    def test_to_dot_empty_tree(self):
+        empty_tree = Tree()
+        export_to_dot(empty_tree, 'tree.dot')
+        
+        expected = """\
+digraph tree {
+
+}"""
+        self.assertTrue(os.path.isfile('tree.dot'), "The file tree.dot could not be found.")
+        generated = self.read_generated_output('tree.dot')
+        
+        self.assertEqual(expected, generated, 'The generated output for an empty tree is not empty')
+        os.remove('tree.dot')
+    
+    def test_unicode_filename(self):
+        tree = Tree()
+        tree.create_node('Node 1', 'node_1')
+        export_to_dot(tree, 'ŕʩϢ.dot')
+        
+        expected = """\
+digraph tree {
+\tnode_1 [label="Node 1", shape=circle]
+
+}"""
+        self.assertTrue(os.path.isfile('ŕʩϢ.dot'), "The file ŕʩϢ.dot could not be found.")
+        generated = self.read_generated_output('ŕʩϢ.dot')
+        self.assertEqual(expected, generated, "The generated file content is not the expected one")
+        os.remove('ŕʩϢ.dot')
+
+    def tearDown(self):
+        self.tree = None
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -278,69 +278,12 @@ Hárry
         self.tree = None
         self.copytree = None
     
-    def read_generated_output(self, filename):
-        output = codecs.open(filename, 'r', 'utf-8')
-        generated = output.read()
-        output.close()
-        
-        return generated
-    
-    def test_to_dot(self):
-        self.tree.to_dot('tree.dot')
-        expected = """\
-digraph tree {
-\thárry [label="Hárry", shape=circle]
-\tbill [label="Bill", shape=circle]
-\tjane [label="Jane", shape=circle]
-\tgeorge [label="George", shape=circle]
-\tdiane [label="Diane", shape=circle]
-
-\thárry -> jane
-\thárry -> bill
-\tbill -> george
-\tjane -> diane
-}"""
-        
-        generated = self.read_generated_output('tree.dot')
-        
-        self.assertEqual(generated, expected, "Generated dot tree is not the expected one")  
-        os.remove('tree.dot')
-        
-    def test_to_dot_empty_tree(self):
-        empty_tree = Tree()
-        empty_tree.to_dot("tree.dot")
-        
-        expected = """\
-digraph tree {
-
-}"""
-        generated = self.read_generated_output('tree.dot')
-        
-        self.assertEqual(expected, generated, 'The generated output for an empty tree is not empty')
-        os.remove('tree.dot')
-    
-    def test_unicode_filename(self):
-        tree = Tree()
-        tree.create_node('Node 1', 'node_1')
-        tree.to_dot('ŕʩϢ.dot')
-        
-        expected = """\
-digraph tree {
-\tnode_1 [label="Node 1", shape=circle]
-
-}"""
-        self.assertTrue(os.path.isfile('ŕʩϢ.dot'), "The file ŕʩϢ.dot could not be found.")
-        generated = self.read_generated_output('ŕʩϢ.dot')
-        self.assertEqual(expected, generated, "The generated file content is not the expected one")
-        os.remove('ŕʩϢ.dot')
-
 def suite():
     suites = [NodeCase, TreeCase]
     suite = unittest.TestSuite()
     for s in suites:
         suite.addTest(unittest.makeSuite(s))
     return suite
-
 
 
 if __name__ == '__main__':

--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 import sys
 import os
+import codecs
 try:
     from StringIO import StringIO as BytesIO
 except ImportError:
@@ -278,8 +279,8 @@ Hárry
         self.copytree = None
     
     def read_generated_output(self, filename):
-        output = open(filename)
-        generated = output.read().decode('utf-8')
+        output = codecs.open(filename, 'r', 'utf-8')
+        generated = output.read()
         output.close()
         
         return generated

--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -331,6 +331,7 @@ digraph tree {
         self.assertTrue(os.path.isfile('ŕʩϢ.dot'), "The file ŕʩϢ.dot could not be found.")
         generated = self.read_generated_output('ŕʩϢ.dot')
         self.assertEqual(expected, generated, "The generated file content is not the expected one")
+        os.remove('ŕʩϢ.dot')
 
 def suite():
     suites = [NodeCase, TreeCase]

--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import sys
+import os
 try:
     from StringIO import StringIO as BytesIO
 except ImportError:
@@ -275,7 +276,61 @@ Hárry
     def tearDown(self):
         self.tree = None
         self.copytree = None
+    
+    def read_generated_output(self, filename):
+        output = open(filename)
+        generated = output.read().decode('utf-8')
+        output.close()
+        
+        return generated
+    
+    def test_to_dot(self):
+        self.tree.to_dot('tree.dot')
+        expected = """\
+digraph tree {
+\thárry [label="Hárry", shape=circle]
+\tbill [label="Bill", shape=circle]
+\tjane [label="Jane", shape=circle]
+\tgeorge [label="George", shape=circle]
+\tdiane [label="Diane", shape=circle]
 
+\thárry -> jane
+\thárry -> bill
+\tbill -> george
+\tjane -> diane
+}"""
+        
+        generated = self.read_generated_output('tree.dot')
+        
+        self.assertEqual(generated, expected, "Generated dot tree is not the expected one")  
+        os.remove('tree.dot')
+        
+    def test_to_dot_empty_tree(self):
+        empty_tree = Tree()
+        empty_tree.to_dot("tree.dot")
+        
+        expected = """\
+digraph tree {
+
+}"""
+        generated = self.read_generated_output('tree.dot')
+        
+        self.assertEqual(expected, generated, 'The generated output for an empty tree is not empty')
+        os.remove('tree.dot')
+    
+    def test_unicode_filename(self):
+        tree = Tree()
+        tree.create_node('Node 1', 'node_1')
+        tree.to_dot('ŕʩϢ.dot')
+        
+        expected = """\
+digraph tree {
+\tnode_1 [label="Node 1", shape=circle]
+
+}"""
+        self.assertTrue(os.path.isfile('ŕʩϢ.dot'), "The file ŕʩϢ.dot could not be found.")
+        generated = self.read_generated_output('ŕʩϢ.dot')
+        self.assertEqual(expected, generated, "The generated file content is not the expected one")
 
 def suite():
     suites = [NodeCase, TreeCase]

--- a/treelib/plugins.py
+++ b/treelib/plugins.py
@@ -1,5 +1,35 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """This is a public location to maintain contributed
-   utlities to extend the basic Tree class.
+   utilities to extend the basic Tree class.
 """
+from __future__ import unicode_literals
+import codecs
+
+def export_to_dot(tree, filename, shape='circle', graph='digraph'):
+    """Exports the tree in the dot format of the graphviz software"""
+        
+    nodes, connections = [], []
+    if tree.nodes:        
+        
+        for n in tree.expand_tree(mode=tree.WIDTH):
+            nid = tree[n].identifier
+            state = nid + ' [label="' + tree[n].tag + '", shape=' + shape + ']'
+            nodes.append(state)
+
+            for c in tree.children(nid):
+                cid = c.identifier
+
+                connections.append(nid + ' -> ' + cid)
+
+    # write nodes and connections to dot format
+    with codecs.open(filename, 'w', 'utf-8') as f:
+        f.write(graph +' tree {\n')
+        for n in nodes:
+            f.write('\t' + n + '\n')
+        
+        f.write('\n')
+        for c in connections:
+            f.write('\t' + c + '\n')
+
+        f.write('}')

--- a/treelib/plugins.py
+++ b/treelib/plugins.py
@@ -33,3 +33,6 @@ def export_to_dot(tree, filename, shape='circle', graph='digraph'):
             f.write('\t' + c + '\n')
 
         f.write('}')
+
+if __name__ == '__main__':
+    pass

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 import sys
 import json
+import codecs
 from copy import deepcopy
 try:
     from .node import Node
@@ -673,7 +674,7 @@ class Tree(object):
 
     def to_dot(self, filename, shape='circle', graph='digraph'):
         """Exports the tree in the dot format of the graphivz software"""
-        
+                
         nodes, connections = [], []
         if self.nodes:        
             
@@ -688,16 +689,14 @@ class Tree(object):
                     connections.append(nid + ' -> ' + cid)
 
         # write nodes and connections to dot format
-        with open(filename, 'w') as f:
+        with codecs.open(filename, 'w', 'utf-8') as f:
             f.write(graph +' tree {\n')
             for n in nodes:
-                out_line = '\t' + n + '\n'
-                f.write(out_line.encode('utf-8'))
+                f.write('\t' + n + '\n')
             
             f.write('\n')
             for c in connections:
-                out_line = '\t' + c + '\n'
-                f.write(out_line.encode('utf-8'))
+                f.write('\t' + c + '\n')
 
             f.write('}')
 

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -672,26 +672,31 @@ class Tree(object):
         return json.dumps(self.to_dict(with_data=with_data, sort=sort, reverse=reverse))
 
     def to_dot(self, filename, shape='circle', graph='digraph'):
-
+        
         nodes, connections = [], []
-        for n in self.expand_tree(mode=self.WIDTH):
-            nid = self[n].identifier
-            state = nid + ' [label="' + self[n].tag + '", shape=' + shape + ']'
-            nodes.append(state)
-
-            for c in self.children(nid):
-                cid = c.identifier
-
-                connections.append(str(nid) + ' -> ' + str(cid))
+        if self.nodes:        
+            
+            for n in self.expand_tree(mode=self.WIDTH):
+                nid = self[n].identifier
+                state = nid + ' [label="' + self[n].tag + '", shape=' + shape + ']'
+                nodes.append(state)
+    
+                for c in self.children(nid):
+                    cid = c.identifier
+    
+                    connections.append(nid + ' -> ' + cid)
 
         # write nodes and connections to dot format
         with open(filename, 'w') as f:
             f.write(graph +' tree {\n')
             for n in nodes:
-                f.write('\t' + n + '\n')
-
+                out_line = '\t' + n + '\n'
+                f.write(out_line.encode('utf-8'))
+            
+            f.write('\n')
             for c in connections:
-                f.write('\t' + c + '\n')
+                out_line = '\t' + c + '\n'
+                f.write(out_line.encode('utf-8'))
 
             f.write('}')
 

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -671,5 +671,29 @@ class Tree(object):
         """Return the json string corresponding to self"""
         return json.dumps(self.to_dict(with_data=with_data, sort=sort, reverse=reverse))
 
+    def to_dot(self, filename, shape='circle', graph='digraph'):
+
+        nodes, connections = [], []
+        for n in self.expand_tree(mode=self.WIDTH):
+            nid = self[n].identifier
+            state = nid + ' [label="' + self[n].tag + '", shape=' + shape + ']'
+            nodes.append(state)
+
+            for c in self.children(nid):
+                cid = c.identifier
+
+                connections.append(str(nid) + ' -> ' + str(cid))
+
+        # write nodes and connections to dot format
+        with open(filename, 'w') as f:
+            f.write(graph +' tree {\n')
+            for n in nodes:
+                f.write('\t' + n + '\n')
+
+            for c in connections:
+                f.write('\t' + c + '\n')
+
+            f.write('}')
+
 if __name__ == '__main__':
     pass

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -672,6 +672,7 @@ class Tree(object):
         return json.dumps(self.to_dict(with_data=with_data, sort=sort, reverse=reverse))
 
     def to_dot(self, filename, shape='circle', graph='digraph'):
+        """Exports the tree in the dot format of the graphivz software"""
         
         nodes, connections = [], []
         if self.nodes:        

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -8,7 +8,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 import sys
 import json
-import codecs
 from copy import deepcopy
 try:
     from .node import Node
@@ -671,34 +670,6 @@ class Tree(object):
     def to_json(self, with_data=False, sort=True, reverse=False):
         """Return the json string corresponding to self"""
         return json.dumps(self.to_dict(with_data=with_data, sort=sort, reverse=reverse))
-
-    def to_dot(self, filename, shape='circle', graph='digraph'):
-        """Exports the tree in the dot format of the graphivz software"""
-                
-        nodes, connections = [], []
-        if self.nodes:        
-            
-            for n in self.expand_tree(mode=self.WIDTH):
-                nid = self[n].identifier
-                state = nid + ' [label="' + self[n].tag + '", shape=' + shape + ']'
-                nodes.append(state)
-    
-                for c in self.children(nid):
-                    cid = c.identifier
-    
-                    connections.append(nid + ' -> ' + cid)
-
-        # write nodes and connections to dot format
-        with codecs.open(filename, 'w', 'utf-8') as f:
-            f.write(graph +' tree {\n')
-            for n in nodes:
-                f.write('\t' + n + '\n')
-            
-            f.write('\n')
-            for c in connections:
-                f.write('\t' + c + '\n')
-
-            f.write('}')
 
 if __name__ == '__main__':
     pass


### PR DESCRIPTION
While using the treelib library I've figured out that there was no possibility to export a tree to the dot format of the Graphviz software package. Only a show method is provided. Therefore I have added a function to export the tree to the dot format and created a few unit tests to check if its working correctly.