### PR TITLE
Print data property for tree nodes

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -155,9 +155,18 @@ You can create a flower tree now:
 .. code-block:: sh
 
     >>> ftree = Tree()
-    >>> ftree.create_node("Root", "root")
+    >>> ftree.create_node("Root", "root", data=Flower("black"))
     >>> ftree.create_node("F1", "f1", parent='root', data=Flower("white"))
     >>> ftree.create_node("F2", "f2", parent='root', data=Flower("red"))
+
+Printing the colors of the tree:
+
+.. code-block:: sh
+
+    >>> ftree.show(data_property="color")
+        black
+        ├── white
+        └── red
 
 **Notes:** Before version 1.2.5, you may need to inherit and modify the behaviors of tree. Both are supported since then. For flower example,
 

--- a/docs/source/pyapi.rst
+++ b/docs/source/pyapi.rst
@@ -217,14 +217,15 @@ Instance methods:
     ``filter`` refers to the function of one variable to act on the
     :class:`Node` object.
 
-.. method:: show([nid[, level[, idhidden[, filter[, key[, reverse[, line_type]]]]]]]])
+.. method:: show([nid[, level[, idhidden[, filter[, key[, reverse[, line_type[, data_property]]]]]]]]])
 
     Print the tree structure in hierarchy style. ``nid`` refers to the
     expanding point to start; ``level`` refers to the node level in the tree
     (root as level 0); ``idhidden`` refers to hiding the node ID when printing;
     ``filter`` refers to the function of one variable to act on the
     :class:`Node` object; ``key``, ``reverse`` are present to sort
-    :class:`Node` object in the same level.
+    :class:`Node` object in the same level. ``data_property`` refers to the property
+    on the node data object to be printed.
 
     You have three ways to output your tree data, i.e., stdout with ``show()``,
     plain text file with ``save2file()``, and json string with ``to_json()``. The

--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -247,6 +247,14 @@ class TreeCase(unittest.TestCase):
         self.assertEqual(self.tree["jill"].data.color, "white")
         self.tree.remove_node("jill")
 
+    def test_show_data_property(self):
+        new_tree = Tree()
+        class Flower(object):
+            def __init__(self, color):
+                self.color = color
+        new_tree.create_node("Jill", "jill", data=Flower("white"))
+        new_tree.show(data_property="color")
+
     def test_level(self):
         self.assertEqual(self.tree.level('hárry'),  0)
         depth = self.tree.depth()


### PR DESCRIPTION
Adds the ability to specify a node property to be printed when displaying the tree. Needed the ability to display other data related to the tree, so the PR is somewhat related to #39.