### PR TITLE
Fixed Documentation and tree.show()

### DIFF
--- a/docs/source/pyapi.rst
+++ b/docs/source/pyapi.rst
@@ -151,6 +151,10 @@ Instance attributes:
     with ``.`` and ``=`` operator respectively.
 
 
+.. method:: nodes
+
+    Return a dict form of nodes in a tree: {id: node_instance}
+
 
 **Instance methods**:
 
@@ -241,11 +245,6 @@ Instance attributes:
 .. method:: move_node(source, destination)
 
     Move node (source) from its parent to another parent (destination).
-
-
-.. method:: nodes()
-
-    Return a dict form of nodes in a tree: {id: node_instance}
 
 
 .. method:: parent (nid)

--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -286,11 +286,20 @@ class TreeCase(unittest.TestCase):
 
     def test_show_data_property(self):
         new_tree = Tree()
-        class Flower(object):
-            def __init__(self, color):
-                self.color = color
-        new_tree.create_node("Jill", "jill", data=Flower("white"))
-        new_tree.show(data_property="color")
+
+        sys.stdout = open(os.devnull, "w")  # stops from printing to console
+
+        try:
+            new_tree.show()
+
+            class Flower(object):
+                def __init__(self, color):
+                    self.color = color
+            new_tree.create_node("Jill", "jill", data=Flower("white"))
+            new_tree.show(data_property="color")
+        finally:
+            sys.stdout.close()
+            sys.stdout = sys.__stdout__  # stops from printing to console
 
     def test_level(self):
         self.assertEqual(self.tree.level('hárry'),  0)
@@ -312,7 +321,13 @@ Hárry
         assert str(self.tree) == encode(expected_result)
 
     def test_show(self):
-        self.tree.show()
+        sys.stdout = open(os.devnull, "w")  # stops from printing to console
+
+        try:
+            self.tree.show()
+        finally:
+            sys.stdout.close()
+            sys.stdout = sys.__stdout__  # stops from printing to console
 
     def tearDown(self):
         self.tree = None

--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -321,9 +321,10 @@ Hárry
         assert str(self.tree) == encode(expected_result)
 
     def test_show(self):
-        reload(sys)
+        if sys.version_info.major < 3:
+            reload(sys)
+            sys.setdefaultencoding('utf-8')
         sys.stdout = open(os.devnull, "w")  # stops from printing to console
-        sys.setdefaultencoding('utf-8')
 
         try:
             self.tree.show()

--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -321,7 +321,7 @@ Hárry
         assert str(self.tree) == encode(expected_result)
 
     def test_show(self):
-        if sys.version_info.major < 3:
+        if sys.version_info[0] < 3:
             reload(sys)
             sys.setdefaultencoding('utf-8')
         sys.stdout = open(os.devnull, "w")  # stops from printing to console

--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -321,7 +321,9 @@ Hárry
         assert str(self.tree) == encode(expected_result)
 
     def test_show(self):
+        reload(sys)
         sys.stdout = open(os.devnull, "w")  # stops from printing to console
+        sys.setdefaultencoding('utf-8')
 
         try:
             self.tree.show()

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -644,8 +644,11 @@ class Tree(object):
         def write(line):
             self.reader += line.decode('utf-8') + "\n"
 
-        self.__print_backend(nid, level, idhidden, filter,
-            key, reverse, line_type, data_property, func=write)
+        try:
+            self.__print_backend(nid, level, idhidden, filter,
+                key, reverse, line_type, data_property, func=write)
+        except NodeIDAbsentError:
+            print('Tree is empty')
 
         print(self.reader)
 


### PR DESCRIPTION
tree.node was changed to an @property function and the documentation was not updated.

tree.show() threw an exception when the tree was empty. It now declares that the tree is empty. A tests has also been added for this.

Suppressed print statements in test_treelib.py