### PR TITLE
Fix Issue #67 - Prevent move_node() from unrooting tree/creating loops

### DIFF
--- a/treelib/node.py
+++ b/treelib/node.py
@@ -61,7 +61,7 @@ class Node(object):
         if nid is not None:
             self._bpointer = nid
         else:
-            # print("WARNNING: the bpointer of node %s " \
+            # print("WARNING: the bpointer of node %s " \
             #      "is set to None" % self._identifier)
             self._bpointer = None
 
@@ -93,7 +93,7 @@ class Node(object):
     def identifier(self, value):
         """Set the value of `_identifier`."""
         if value is None:
-            print("WARNNING: node ID can not be None")
+            print("WARNING: node ID can not be None")
         else:
             self._set_identifier(value)
 
@@ -133,7 +133,7 @@ class Node(object):
             if nid in self._fpointer:
                 self._fpointer.remove(nid)
         elif mode is self.INSERT:  # deprecate to ADD mode
-            print("WARNNING: INSERT is deprecated to ADD mode")
+            print("WARNING: INSERT is deprecated to ADD mode")
             self.update_fpointer(nid)
 
     def __repr__(self):

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -52,6 +52,14 @@ class LinkPastRootNodeError(Exception):
 class InvalidLevelNumber(Exception):
     pass
 
+
+class DerootTreeAttempt(Exception):
+    """
+    Exception thrown if any attempt is made to deroot the tree,
+    as in when calling Tree.move_node(root, destination).
+    """
+    pass
+
 def python_2_unicode_compatible(klass):
     """
     (slightly modified from :
@@ -465,9 +473,17 @@ class Tree(object):
             raise NodeIDAbsentError
 
         parent = self[source].bpointer
-        self.__update_fpointer(parent, source, Node.DELETE)
-        self.__update_fpointer(destination, source, Node.ADD)
-        self.__update_bpointer(source, destination)
+        if self[source].is_root():
+            raise DerootTreeAttempt
+        elif self[destination].bpointer == source:
+            # Special case where we exchange child/parent
+            self.move_node(destination, parent)
+            self.move_node(source, destination)
+        else:
+            # General case
+            self.__update_fpointer(parent, source, Node.DELETE)
+            self.__update_fpointer(destination, source, Node.ADD)
+            self.__update_bpointer(source, destination)
 
     @property
     def nodes(self):


### PR DESCRIPTION
~~~
move_node() will no longer create loops
Added an exception to prevent derooting
 the tree, as is done with
        move_node(root, destination)
~~~

---

Run the following under original and under proposal to see effects:

~~~ python
from tree import Tree

tree = Tree()
tree.create_node('a', 'a')
tree.create_node('b', 'b', parent='a')
tree.create_node('c', 'c', parent='b')
tree.create_node('d', 'd', parent='b')
tree.create_node('e', 'e', parent='b')
tree.create_node('f', 'f', parent='b')
tree.show()
tree.move_node('b', 'c')
tree.show()
~~~

Calling code from Issue #67 will now throw exception `DerootTreeAttempt`, disallowing anyone from derooting the tree.