### PR TITLE
Fix unicode print error,

### DIFF
--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -674,7 +674,7 @@ class Tree(object):
         except NodeIDAbsentError:
             print('Tree is empty')
 
-        print(self.reader)
+        print(self.reader.encode('utf-8'))
 
     def siblings(self, nid):
         """


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "D:\User\Dropbox\Applications\SoftwareVersioning\ComputerScienceGraduation\Semester20171\treelib\test.py", line 14, in <module>
    tree.show()
  File "D:\User\Dropbox\Applications\SoftwareVersioning\ComputerScienceGraduation\Semester20171\treelib\treelib\tree.py", line 677, in show
    print(self.reader)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 6-8: ordinal not in range(128)
```

By the input:
```python

from treelib import Node, Tree

tree = Tree()
tree.create_node("Harry", "harry")  # root node
tree.create_node("Jane", "jane", parent="harry")
tree.create_node("Bill", "bill", parent="harry")
tree.create_node("Diane", "diane", parent="jane")
tree.create_node("Mary", "mary", parent="diane")
tree.create_node("Mark", "mark", parent="jane")
tree.show()
```

Using the answer on:
http://stackoverflow.com/questions/9942594/unicodeencodeerror-ascii-codec-cant-encode-character-u-xa0-in-position-20/9942885#9942885