### PR TITLE
Implement correct level feature in tree.size and corresponding tests

### DIFF
--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -309,6 +309,11 @@ class TreeCase(unittest.TestCase):
                                          lambda x: x.identifier!='jane'),
                          depth-1)
 
+    def test_size(self):
+        self.assertEqual(self.tree.size(level=2), 2)
+        self.assertEqual(self.tree.size(level=1), 2)
+        self.assertEqual(self.tree.size(level=0), 1)
+
     def test_print_backend(self):
         expected_result = """\
 Hárry

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -703,7 +703,15 @@ class Tree(object):
 
         Otherwise, InvalidLevelNumber exception will be raised.
         """
-        return len(self._nodes)
+        if level is None:
+            return len(self._nodes)
+        else:
+            try:
+                level = int(level)
+            except:
+                raise TypeError("level should be an integer instead of '%s'" % type(level))
+            return len([node for node in self.all_nodes_itr() if self.level(node.identifier) == level])
+            
 
     def subtree(self, nid):
         """


### PR DESCRIPTION
Just an quick implementation of the level option in tree.size and the corresponding tests.
Works fine for my python3.6 and python2.7 in my ~290000-nodes/8-levels tree. Haven't tested any other python version.
HTH,
Florent