### PR TITLE
Add ancestor method to class Tree & corresponding test

### DIFF
--- a/tests/test_treelib.py
+++ b/tests/test_treelib.py
@@ -139,6 +139,15 @@ class TreeCase(unittest.TestCase):
                 self.assertEqual(self.tree.parent(nid) in \
                                  self.tree.all_nodes(), True)
 
+    def test_ancestor(self):
+        for nid in self.tree.nodes:
+            if nid == self.tree.root:
+                self.assertEqual(self.tree.ancestor(nid), None)
+            else:
+                for level in range(self.tree.level(nid) - 1, 0, -1):
+                    self.assertEqual(self.tree.ancestor(nid, level=level) in \
+                                     self.tree.all_nodes(), True)
+
     def test_children(self):
         for nid in self.tree.nodes:
             children = self.tree.is_branch(nid)

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -295,6 +295,35 @@ class Tree(object):
         """
         return self._nodes.values()
 
+    def ancestor(self, nid, level=None):
+        """
+        For a given id, get ancestor node object at a given level.
+        If no level is provided, the parent node is returned.
+        """
+        if not self.contains(nid):
+            raise NodeIDAbsentError("Node '%s' is not in the tree" % nid)
+
+        descendant = self[nid]
+        ascendant = self[nid].bpointer
+        ascendant_level = self.level(ascendant)
+
+        if level is None:
+            return ascendant
+        elif nid == self.root:
+            return self[nid]
+        elif level >= self.level(descendant.identifier):
+            raise InvalidLevelNumber("Descendant level (level %s) must be greater \
+                                      than its ancestor's level (level %s)" % (str(self.level(descendant.identifier)), level))
+
+        while ascendant is not None:
+            if ascendant_level == level:
+                return self[ascendant]
+            else:
+                descendant = ascendant
+                ascendant = self[descendant].bpointer
+                ascendant_level = self.level(ascendant)
+        return None
+
     def children(self, nid):
         """
         Return the children (Node) list of nid.


### PR DESCRIPTION
Add a new method to class Tree to find ancestor at a given level, and the corresponding test function.
Ex: my_tree.ancestor(nid, level=1) will return, for node nid, the ancestor of level 1 from my_tree