### PR TITLE
Node sorting during tree traversal made optional

### DIFF
--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -167,17 +167,29 @@ class TreeCase(unittest.TestCase):
         #       |-- Diane
         #   |-- Bill
         #       |-- George
+        # Traverse in depth first mode preserving insertion order
         nodes = [nid for nid in self.tree.expand_tree(sorting=False)]
         self.assertEqual(nodes, [u'h\xe1rry', u'jane', u'diane', u'bill', u'george'])
         self.assertEqual(len(nodes), 5)
 
+        # By default traverse depth first and sort child nodes by node tag
+        nodes = [nid for nid in self.tree.expand_tree()]
+        self.assertEqual(nodes, [u'h\xe1rry', u'bill', u'george', u'jane', u'diane'])
+        self.assertEqual(len(nodes), 5)
+
         ## expanding from specific node
         nodes = [nid for nid in self.tree.expand_tree(nid="bill")]
+        self.assertEqual(nodes, [u'bill', u'george'])
         self.assertEqual(len(nodes), 2)
 
-        ## changing into width mode
+        ## changing into width mode preserving insertion order
         nodes = [nid for nid in self.tree.expand_tree(mode=Tree.WIDTH, sorting=False)]
         self.assertEqual(nodes, [u'h\xe1rry', u'jane', u'bill', u'diane', u'george'])
+        self.assertEqual(len(nodes), 5)
+
+        # Breadth first mode, child nodes sorting by tag
+        nodes = [nid for nid in self.tree.expand_tree(mode=Tree.WIDTH)]
+        self.assertEqual(nodes, [u'h\xe1rry', u'bill', u'jane',  u'george', u'diane'])
         self.assertEqual(len(nodes), 5)
 
         ## expanding by filters

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -32,13 +32,11 @@ class TreeCase(unittest.TestCase):
         tree.create_node("Bill", "bill", parent="hárry")
         tree.create_node("Diane", "diane", parent="jane")
         tree.create_node("George", "george", parent="bill")
-        """
-        Hárry
-        ├── Bill
-        │   └── George
-        └── Jane
-            └── Diane
-        """
+        # Hárry
+        #   |-- Jane
+        #       |-- Diane
+        #   |-- Bill
+        #       |-- George
         self.tree = tree
         self.copytree = Tree(self.tree, True)
 
@@ -164,8 +162,13 @@ class TreeCase(unittest.TestCase):
 
     def test_expand_tree(self):
         ## default config
-        nodes = [nid for nid in self.tree.expand_tree()]
-        # self.assertEqual(nodes, [u'h\xe1rry', u'bill', u'george', u'jane', u'diane'])
+        # Hárry
+        #   |-- Jane
+        #       |-- Diane
+        #   |-- Bill
+        #       |-- George
+        nodes = [nid for nid in self.tree.expand_tree(sorting=False)]
+        self.assertEqual(nodes, [u'h\xe1rry', u'jane', u'diane', u'bill', u'george'])
         self.assertEqual(len(nodes), 5)
 
         ## expanding from specific node
@@ -173,15 +176,16 @@ class TreeCase(unittest.TestCase):
         self.assertEqual(len(nodes), 2)
 
         ## changing into width mode
-        nodes = [nid for nid in self.tree.expand_tree(mode=Tree.WIDTH)]
-        # self.assertEqual(nodes, [u'h\xe1rry', u'bill', u'jane', u'george', u'diane'])
+        nodes = [nid for nid in self.tree.expand_tree(mode=Tree.WIDTH, sorting=False)]
+        self.assertEqual(nodes, [u'h\xe1rry', u'jane', u'bill', u'diane', u'george'])
         self.assertEqual(len(nodes), 5)
 
         ## expanding by filters
+        # Stops at root
         nodes = [nid for nid in self.tree.expand_tree(filter = lambda x: x.tag == "Bill")]
         self.assertEqual(len(nodes), 0)
         nodes = [nid for nid in self.tree.expand_tree(filter = lambda x: x.tag != "Bill")]
-        # self.assertEqual(nodes, [u'h\xe1rry', u'jane', u'diane'])
+        self.assertEqual(nodes, [u'h\xe1rry', u'jane', u'diane'])
         self.assertEqual(len(nodes), 3)
 
     def test_move_node(self):

--- a/treelib/__init__.py
+++ b/treelib/__init__.py
@@ -16,7 +16,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '1.5.3'
+__version__ = '1.5.4'
 
 from .tree import Tree
 from .node import Node


### PR DESCRIPTION
Added an optional 'sorting' parameter to Tree.expand_tree() so that tree traversal can be operated without sorting nodes. Parameter defaults to True (sorting enabled) in order to keep backward compatibility.
Rationale: if children sorting is always enabled it's impossible to traverse the tree preserving the original insertion order or, better, it is necessary to explicitly keep track of insertion order using other attributes.