### PR TITLE
New Tree.children_itr method

### DIFF
--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -97,6 +97,8 @@ class TreeCase(unittest.TestCase):
             children = self.tree.children(nid)
             for child in children:
                 self.assertEqual(child in self.tree.all_nodes(), True)
+            children_from_itr = list(self.tree.children_itr(nid))
+            self.assertEqual(children, children_from_itr)
         try:
             self.tree.is_branch("alien")
         except NodeIDAbsentError:

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -296,6 +296,13 @@ class Tree(object):
         """
         return [self[i] for i in self.is_branch(nid)]
 
+    def children_itr(self, nid):
+        """
+        Return the children (Node) of nid as an iterator.
+        Empty iterator is returned if nid does not exist
+        """
+        return (self[i] for i in self.is_branch(nid))
+
     def contains(self, nid):
         """Check if the tree contains node of given id"""
         return True if nid in self._nodes else False


### PR DESCRIPTION
In case creating a list like Tree.children() does is too heavy for efficiency reasons.