### PR TITLE
to_dict() did not pass key on recursion for sort

### DIFF
--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -852,7 +852,7 @@ class Tree(object):
 
             for elem in queue:
                 tree_dict[ntag]["children"].append(
-                    self.to_dict(elem.identifier, with_data=with_data, sort=sort, reverse=reverse))
+                    self.to_dict(elem.identifier, key=key, with_data=with_data, sort=sort, reverse=reverse))
             if len(tree_dict[ntag]["children"]) == 0:
                 tree_dict = self[nid].tag if not with_data else \
                     {ntag: {"data": self[nid].data}}


### PR DESCRIPTION
Added the @key parameter to the self.to_dict so that child nodes are also sorted by the key