### PR TITLE
Additional support for subclassing of 'treelib.Node' 

### DIFF
--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -617,6 +617,25 @@ Hárry
         node = tree.create_node()
         self.assertTrue(isinstance(node, SubNode))
 
+    def test_subclassing_extra_kwargs(self):
+        class SubNode(Node):
+            def __init__(self, some_argument=None, **kwargs):
+                self.some_property = some_argument
+                super().__init__(**kwargs)
+
+        class SubTree(Tree):
+            node_class = SubNode
+
+        tree = SubTree()
+        node = tree.create_node(some_argument="some_value")
+        self.assertTrue(isinstance(node, SubNode))
+        self.assertEqual(node.some_property, "some_value")
+
+        tree = Tree(node_class=SubNode)
+        node = tree.create_node(some_argument="some_value")
+        self.assertTrue(isinstance(node, SubNode))
+        self.assertEqual(node.some_property, "some_value")
+
     def test_shallow_copy_hermetic_pointers(self):
         # tree 1
         # Hárry

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -336,12 +336,12 @@ class Tree(object):
         """Check if the tree contains node of given id"""
         return True if nid in self._nodes else False
 
-    def create_node(self, tag=None, identifier=None, parent=None, data=None):
+    def create_node(self, tag=None, identifier=None, parent=None, data=None, **kwargs):
         """
         Create a child node for given @parent node. If ``identifier`` is absent,
         a UUID will be generated automatically.
         """
-        node = self.node_class(tag=tag, identifier=identifier, data=data)
+        node = self.node_class(tag=tag, identifier=identifier, data=data, **kwargs)
         self.add_node(node, parent)
         return node
 


### PR DESCRIPTION
In my own project I am extensively subclassing both 'treelib.Tree' and 'treelib.Node'. Using the 'data' variable, as mentioned in the documentation under advanced usage, does not work well for my use case. 

It would make my life easier, and my code prettier, if I can pass additional arguments to Tree.create_node. The dependency injection is already there (self.node_class) and this PR should unlock more of the potential. https://github.com/caesar0301/treelib/blob/017e891fcd5dc613004061cdc42e65cebea48ced/treelib/tree.py#L339-L346