### PR TITLE
Add sorting parameter for show() and save2file()

### DIFF
--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -559,6 +559,23 @@ Hárry
         self.tree = None
         self.copytree = None
 
+    def test_show_without_sorting(self):
+        t = Tree()
+        t.create_node('Students', 'Students', parent=None)
+        Node(tag='Students', identifier='Students', data=None)
+        t.create_node('Ben', 'Ben',parent='Students')
+        Node(tag='Ben', identifier='Ben', data=None)
+        t.create_node('Annie', 'Annie',parent='Students')
+        Node(tag='Annie', identifier='Annie', data=None)
+        t.show()
+        self.assertEqual(
+            t.show(sorting=False, stdout=False),
+            """Students
+├── Ben
+└── Annie
+""",
+        )
+
     def test_all_nodes_itr(self):
         """
         tests: Tree.all_nodes_iter


### PR DESCRIPTION
Resolve #170 with `show(sorting=False)` to display the tree while maintaining insertion order.

Signed-off-by: Hollow Man <hollowman@hollowman.ml>