### PR TITLE
Removed legacy ordering in Tree.__print_backend()

### DIFF
--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -186,11 +186,6 @@ class Tree(object):
                 def get_label(node):
                     return "%s[%s]" % (node.tag, node.identifier)
 
-        # legacy ordering
-        if key is None:
-            def key(node):
-                return node
-
         # iter with func
         for pre, node in self.__get(nid, level, filter, key, reverse,
                                     line_type):


### PR DESCRIPTION
* Having legacy ordering in the current form makes it impossible to print a tree
  without any ordering at all
* Legacy ordering is invoked whenever ``key=None``, so it renders control over
  ordering ineffective