### PR TITLE
replace future with six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license="Apache License, Version 2.0",
     packages=['treelib'],
     keywords=['data structure', 'tree', 'tools'],
-    install_requires=["future"],
+    install_requires=["six"],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -38,7 +38,7 @@ import codecs
 import json
 import uuid
 from copy import deepcopy
-from future.utils import python_2_unicode_compatible, iteritems
+from six import python_2_unicode_compatible, iteritems
 
 try:
     from StringIO import StringIO


### PR DESCRIPTION
Can I convince you to use `six` instead of `python-future` for py2/py3 compatibility? 

`six` seems to be the most popular solution to this, with equivalent names for your usage, and the other project has a few issues that will never be fixed and is annoying for me to have as a sub-dependency.

* ran tests with py2 and py3 w/ pytest