### PR TITLE
Fixed bug when exporting to graphviz dot format as undirected graph

### DIFF
--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -969,7 +969,8 @@ class Tree(object):
 
                 for c in self.children(nid):
                     cid = c.identifier
-                    connections.append('"{0}" -> "{1}"'.format(nid, cid))
+                    edge = '->' if graph == 'digraph' else '--'
+                    connections.append(('"{0}" ' + edge + ' "{1}"').format(nid, cid))
 
         # write nodes and connections to dot format
         is_plain_file = filename is not None


### PR DESCRIPTION
When exporting to the graphviz dot format, the edge between nodes will always be "->" but when not exporting as "digraph" (but as undirected "graph"), the dot format requires the *edgeop* to be "--".

Feel free to fix this issue yourself, if that's more convenient than merging this pull request.