### PR TITLE
Fix the print string to diplay, before it was printing an unformatted…

### DIFF
--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -929,7 +929,7 @@ class Tree(object):
             print("Tree is empty")
 
         if stdout:
-            print(self._reader.encode("utf-8"))
+            print(self._reader)
         else:
             return self._reader
 


### PR DESCRIPTION
Fix the print string to diplay, before it was printing an unformatted
I discovered this bug in the .show() method of the Tree class: whenever I try to print to stdout the Tree structure I get a messy string of Bytes, instead of a proper string with the supposed schema:
![image](https://github.com/caesar0301/treelib/assets/36136101/6e45af80-72c0-4b40-9aad-b7f8f676d852)
I removed the ".encode("utf-8")" from the self._reader to display and the print to stdout works as advertised:
![image](https://github.com/caesar0301/treelib/assets/36136101/0ab02446-50f7-40d2-9857-e9256b7f2698)
