### PR TITLE
tree: add render_node arg to __print_backend

### DIFF
--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -521,6 +521,37 @@ class TreeCase(unittest.TestCase):
             sys.stdout.close()
             sys.stdout = sys.__stdout__  # stops from printing to console
 
+    def test_show_render_node(self):
+        product_tree = Tree()
+
+        def callback_fn(node):
+            if node.is_leaf():
+                return f"A {node.data.color} {node.data.brand} car"
+            return node.identifier
+
+        class Product(object):
+            def __init__(self, brand, color):
+                self.brand = brand
+                self.color = color
+
+        product_tree.create_node(tag="root", identifier="root", data={"level": 0})
+        product_tree.create_node(identifier="car", parent="root", data={"level": 1})
+        product_tree.create_node(
+            identifier="car_byd", parent="car", data=Product("BYD", "red")
+        )
+        product_tree.create_node(
+            identifier="car_geely", parent="car", data=Product("Geely", "green")
+        )
+
+        self.assertEqual(
+            product_tree.show(stdout=False, render_node=callback_fn),
+            """root
+└── car
+    ├── A red BYD car
+    └── A green Geely car
+""",
+        )
+
     def test_level(self):
         self.assertEqual(self.tree.level("hárry"), 0)
         depth = self.tree.depth()

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -162,6 +162,7 @@ class Tree(object):
         reverse=False,
         line_type="ascii-ex",
         data_property=None,
+        render_node=None,
         sorting=True,
         func=print,
     ):
@@ -190,7 +191,10 @@ class Tree(object):
         level.
         """
         # Factory for proper get_label() function
-        if data_property:
+        if render_node:
+            get_label = render_node
+
+        elif data_property:
             if idhidden:
 
                 def get_label(node):
@@ -842,6 +846,7 @@ class Tree(object):
         reverse=False,
         line_type="ascii-ex",
         data_property=None,
+        render_node=None,
         sorting=True,
     ):
         """
@@ -863,6 +868,7 @@ class Tree(object):
             reverse,
             line_type,
             data_property,
+            render_node,
             sorting,
             func=handler,
         )
@@ -877,6 +883,7 @@ class Tree(object):
         reverse=False,
         line_type="ascii-ex",
         data_property=None,
+        render_node=None,
         stdout=True,
         sorting=True,
     ):
@@ -922,6 +929,7 @@ class Tree(object):
                 reverse,
                 line_type,
                 data_property,
+                render_node,
                 sorting,
                 func=write,
             )

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -909,6 +909,8 @@ class Tree(object):
         :param reverse: the ``reverse`` param for sorting :class:`Node` objects in the same level.
         :param line_type:
         :param data_property: the property on the node data object to be printed.
+        :param render_node: a callback function that receives `node` and should return a string.
+            Useful when you want to have full control over how each node is rendered.
         :param sorting: if True perform node sorting, if False return
             nodes in original insertion order. In latter case @key and
             @reverse parameters are ignored.


### PR DESCRIPTION
This let us do [inversion of control](https://en.wikipedia.org/wiki/Inversion_of_control), passing in a callback function that gives more flexibility into how the node is rendered when using `show()` and `save2file()`. Essentially replaces the need for `data_property` - but we should probably keep it for backwards compatibility.

The callback function right now expect a `string` to be returned. I was thinking on maybe supporting `None` which could also replace the need for the `filter` argument: Return `None` to avoid the Node to be rendered. Let me know what you think @liamlundy  or @caesar0301 :) 

**Example:**

```py
def render_node(node):
  if node.is_leaf():
    return node.my_property
  return node.some_other_property

tree.show(render_node=render_node)
```

See unit test in [626f439](https://github.com/caesar0301/treelib/pull/227/commits/626f439fd7348fee5e67abe2ea5a375944794103) for an actual example.


## Checklist

- [x] I have formatted my code with Black I pass the local validation with `scripts/flake8.sh`.
- [ ] I have updated docs: Please point me in the right direction here - I've added a docstring, but I'm not sure what/how/where to document the updated `show()` API.