### PR TITLE
Escape double quotes in graphviz labels

### DIFF
--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -1097,7 +1097,8 @@ class Tree(object):
                 sorting=sorting,
             ):
                 nid = self[n].identifier
-                state = '"{0}" [label="{1}", shape={2}]'.format(nid, self[n].tag, shape)
+                tag = str(self[n].tag).translate(str.maketrans({'"': r"\""}))
+                state = '"{0}" [label="{1}", shape={2}]'.format(nid, tag, shape)
                 nodes.append(state)
 
                 for c in self.children(nid):

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -1097,8 +1097,8 @@ class Tree(object):
                 sorting=sorting,
             ):
                 nid = self[n].identifier
-                tag = str(self[n].tag).translate(str.maketrans({'"': r"\""}))
-                state = '"{0}" [label="{1}", shape={2}]'.format(nid, tag, shape)
+                label = str(self[n].tag).translate(str.maketrans({'"': r"\""}))
+                state = '"{0}" [label="{1}", shape={2}]'.format(nid, label, shape)
                 nodes.append(state)
 
                 for c in self.children(nid):


### PR DESCRIPTION
Double quotes in labels are making the dot syntax invalid. Escaping them works.