### PR TITLE
Add types for Node.predecessor(), Tree._clone(), Tree.subtree() and Tree.to_dict()

### DIFF
--- a/treelib/node.py
+++ b/treelib/node.py
@@ -30,7 +30,7 @@ import uuid
 import sys
 from collections import defaultdict
 from warnings import warn
-from typing import cast, List, Any, Optional, Union
+from typing import Any, cast, List, Optional, Union
 
 from .exceptions import NodePropertyError
 from .misc import deprecated
@@ -139,7 +139,7 @@ class Node(object):
         """Deprecated"""
         self.update_successors(nid, mode, replace, self._initial_tree_id)
 
-    def predecessor(self, tree_id):
+    def predecessor(self, tree_id: str) -> Optional[str]:
         """
         The parent ID of a node in a given tree.
         """

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -1108,7 +1108,7 @@ class Tree(object):
     def to_dict(
         self,
         nid: Optional[str] = None,
-        key: Optional[str] = None,
+        key: Optional[Callable[[str], Any]] = None,
         sort: bool = True,
         reverse: bool = False,
         with_data: bool = False,

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -40,7 +40,7 @@ import uuid
 import sys
 from copy import deepcopy
 from six import python_2_unicode_compatible, iteritems
-from typing import cast, List, Any, Callable, Optional, Union
+from typing import Any, Callable, cast, Dict, List, Optional, Union
 
 try:
     from StringIO import StringIO  # type: ignore
@@ -118,7 +118,7 @@ class Tree(object):
         identifier: Optional[str] = None,
         with_tree: bool = False,
         deep: bool = False,
-    ):
+    ) -> "Tree":
         """Clone current instance, with or without tree.
 
         Method intended to be overloaded, to avoid rewriting whole "subtree" and "remove_subtree" methods when
@@ -1035,7 +1035,7 @@ class Tree(object):
                     "level should be an integer instead of '%s'" % type(level)
                 )
 
-    def subtree(self, nid: str, identifier: Optional[str] = None):
+    def subtree(self, nid: str, identifier: Optional[str] = None) -> "Tree":
         """
         Return a shallow COPY of subtree with nid being the new root.
         If nid is None, return an empty tree.
@@ -1105,7 +1105,14 @@ class Tree(object):
             else:
                 setattr(cn, attr, val)
 
-    def to_dict(self, nid=None, key=None, sort=True, reverse=False, with_data=False):
+    def to_dict(
+        self,
+        nid: Optional[str] = None,
+        key: Optional[str] = None,
+        sort: bool = True,
+        reverse: bool = False,
+        with_data: bool = False,
+    ) -> Dict[str, Any]:
         """Transform the whole tree into a dict."""
 
         nid = self.root if (nid is None) else nid


### PR DESCRIPTION
Hi @caesar0301, following https://github.com/caesar0301/treelib/pull/232 I found some functions that I use in treelib which were left untyped, so I added type annotations to them.

Hopefully these are correct and it helps. I ran `scripts/flake8.sh` and no issues were flagged, but there isn't coverage around the actual typing itself.