### PR TITLE
FIX: setup.cfg incompatibility with setuptools v78

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Setuptools v78.0.0 started enforcing the following deprecation: https://setuptools.pypa.io/en/stable/history.html#v78-0-0

> Setuptools no longer accepts options containing uppercase or dash characters in setup.cfg. Please ensure to write the options in setup.cfg using the lower_snake_case convention (e.g. Name => name, install-requires => install_requires). This is a follow-up on deprecations introduced in v54.1.0 (see #1608) and v54.1.1 (see #2592).

Without this fix, trying to install treelib with the new setuptools version will yield the following error:
```
setuptools.errors.InvalidConfigError: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name 'description_file' instead.
```