### PR TITLE
Added from_json() function and also added option to add identifier in…

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install Poetry
       uses: snok/install-poetry@v1
       with:
-        version: ${{ (matrix.python-version == '3.7' && '1.5.1' || (matrix.python-version == '3.8' && '1.7.1' || 'latest')) }}
+        version: ${{ (matrix.python-version == '3.7' && '1.5.1' || (matrix.python-version == '3.8' && '1.7.1' || (matrix.python-version == '3.9' && '1.8.5' || 'latest'))) }}
         virtualenvs-create: true
         virtualenvs-in-project: true
         installer-parallel: true

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -486,6 +486,55 @@ class TreeCase(unittest.TestCase):
         self.tree.to_json()
         self.tree.to_json(True)
 
+    def test_from_json_structure(self):
+        t = Tree()
+        r = t.create_node("Root")
+        c1 = t.create_node("Child1", parent=r)
+        c2 = t.create_node("Child2", parent=r)
+
+        restored = Tree.from_json(t.to_json())
+
+        self.assertEqual(restored.size(), t.size())
+        self.assertEqual(restored.get_node(restored.root).tag, "Root")
+        self.assertEqual({c.tag for c in restored.children(restored.root)}, {"Child1", "Child2"})
+        self.assertEqual(t.to_json(), restored.to_json())
+
+    def test_from_json_with_data(self):
+        t = Tree()
+        r = t.create_node(tag="root", data={"val": 42})
+        t.create_node("child1", parent=r, data=None)
+        t.create_node("child2", parent=r, data={"name": "Christian"})
+
+        nd = Tree.from_json(t.to_json(with_data=False))
+
+        self.assertEqual(nd.get_node(nd.root).data, None)
+        self.assertEqual(nd.children(nd.root)[0].data, None)
+        self.assertEqual(nd.children(nd.root)[1].data, None)
+
+        wd = Tree.from_json(t.to_json(with_data=True))
+
+        self.assertEqual(wd.get_node(wd.root).data, {"val": 42})
+        self.assertEqual(wd.children(wd.root)[0].data, None)
+        self.assertEqual(wd.children(wd.root)[1].data, {"name": "Christian"})
+
+    def test_from_json_with_identifier(self):
+        t = Tree()
+        r = t.create_node(identifier="root")
+        c1 = t.create_node("child1", identifier="c1", parent=r)
+        c2 = t.create_node("child2", identifier="c2", parent=r)
+
+        ni = Tree.from_json(t.to_json(with_identifier=False))
+
+        self.assertNotEqual(ni.root, t.root)
+        self.assertNotEqual(ni.children(ni.root)[0].identifier, c1.identifier)
+        self.assertNotEqual(ni.children(ni.root)[1].identifier, c2.identifier)
+
+        wi = Tree.from_json(t.to_json(with_identifier=True))
+
+        self.assertEqual(wi.root, t.root)
+        self.assertEqual(wi.children(wi.root)[0].identifier, c1.identifier)
+        self.assertEqual(wi.children(wi.root)[1].identifier, c2.identifier)
+
     def test_siblings(self):
         self.assertEqual(len(self.tree.siblings("hárry")) == 0, True)
         self.assertEqual(self.tree.siblings("jane")[0].identifier == "bill", True)

--- a/treelib/tree.py
+++ b/treelib/tree.py
@@ -237,6 +237,31 @@ class Tree(object):
                 if tree.identifier != self._identifier:
                     new_node.clone_pointers(tree.identifier, self._identifier)
 
+    @classmethod
+    def from_json(cls, raw: Union[str, bytes, bytearray]):
+        """
+        Load tree from exported JSON.
+        """
+        tree = cls()
+        json_parsed = json.loads(raw)
+
+        def _append_node(subtree, parent_id=None):
+            for tag, node_info in subtree.items():
+                node_id = node_info.get("id") or None
+                node_data = node_info.get("data") or None
+
+                node = tree.create_node(tag=tag, identifier=node_id, parent=parent_id, data=node_data)
+
+                if isinstance(node_info, dict):
+                    for child in node_info.get("children", []):
+                        if isinstance(child, dict):
+                            _append_node(child, parent_id=node.identifier)
+                        else:
+                            tree.create_node(tag=str(child), parent=node.identifier)
+
+        _append_node(json_parsed)
+        return tree
+
     def _clone(
         self,
         identifier: Optional[str] = None,
@@ -1955,30 +1980,45 @@ class Tree(object):
         sort: bool = True,
         reverse: bool = False,
         with_data: bool = False,
+        with_identifier: bool = False,
     ) -> Union[str, Dict[str, Any]]:
         """Transform the whole tree into a dict."""
 
         nid = self.root if (nid is None) else nid
         ntag = self[nid].tag
-        tree_dict = {ntag: {"children": []}}
+        node = self[nid]
+
+        successors = node.successors(self._identifier) if node.expanded else []
+        queue = [self[i] for i in successors]
+        if sort and queue:
+            queue.sort(key=key or (lambda x: x), reverse=reverse)
+
+        children = [
+            self.to_dict(
+                e.identifier,
+                key=key,
+                sort=sort,
+                reverse=reverse,
+                with_data=with_data,
+                with_identifier=with_identifier,
+            )
+            for e in queue
+        ]
+
+        if not children and not with_data and not with_identifier:
+            return ntag
+
+        node_dict = {}
+        if with_identifier:
+            node_dict["id"] = node.identifier
         if with_data:
-            tree_dict[ntag]["data"] = self[nid].data
+            node_dict["data"] = node.data
+        if children:
+            node_dict["children"] = children
 
-        if self[nid].expanded:
-            queue = [self[i] for i in self[nid].successors(self._identifier)]
-            key = (lambda x: x) if (key is None) else key
-            if sort:
-                queue.sort(key=key, reverse=reverse)
+        return {ntag: node_dict}
 
-            for elem in queue:
-                tree_dict[ntag]["children"].append(
-                    self.to_dict(elem.identifier, with_data=with_data, sort=sort, reverse=reverse)
-                )
-            if len(tree_dict[ntag]["children"]) == 0:
-                tree_dict = self[nid].tag if not with_data else {ntag: {"data": self[nid].data}}
-            return tree_dict
-
-    def to_json(self, with_data: bool = False, sort: bool = True, reverse: bool = False):
+    def to_json(self, with_data: bool = False, with_identifier=False, sort: bool = True, reverse: bool = False):
         """
         Export the tree structure as a JSON string.
 
@@ -2064,7 +2104,9 @@ class Tree(object):
             in node.data must be JSON-serializable (no functions, custom classes
             without __dict__, etc.).
         """
-        return json.dumps(self.to_dict(with_data=with_data, sort=sort, reverse=reverse))
+        return json.dumps(
+            self.to_dict(with_data=with_data, with_identifier=with_identifier, sort=sort, reverse=reverse)
+        )
 
     def to_graphviz(
         self,


### PR DESCRIPTION
Solves backwards compatibility issue in #239 by making the identifier and option in the `to_dict()` and `to_json()` functions.  Also, added the class method `from_json()`.

@liamlundy I didn't write any tests for this specifically for this, but it shouldn't be necessary since this is an optional feature.  Let me know if you _want_ tests though, and if you want more tests for `to_dict()` and `to_json()`.